### PR TITLE
fix(user): correct import path for pagination helpers

### DIFF
--- a/src/repositories/event/EventRepository.ts
+++ b/src/repositories/event/EventRepository.ts
@@ -14,7 +14,7 @@ import {
   IPaginationResult,
   normalizePaginationParams,
 } from '../../helpers/pagination.js'
-import { buildSortCriteria, createSortValidator } from 'helpers/sortValidations.js'
+import { buildSortCriteria, createSortValidator } from '../../helpers/sortValidations.js'
 
 const ALLOWED_SORT_FIELDS = ['title', 'start', 'end'] as const
 

--- a/src/repositories/user/UserRepository.ts
+++ b/src/repositories/user/UserRepository.ts
@@ -13,7 +13,7 @@ import {
   IPaginationParams,
   IPaginationResult,
   normalizePaginationParams,
-} from 'helpers/pagination.js'
+} from '../../helpers/pagination.js'
 
 const ALLOWED_SORT_FIELDS = ['firstName', 'lastName', 'email'] as const
 

--- a/src/services/user/UserServiceImpl.ts
+++ b/src/services/user/UserServiceImpl.ts
@@ -6,7 +6,7 @@ import { ApiError } from '../../config/middlewares/ApiError.js'
 import { BaseServiceImpl } from '../BaseServiceImpl.js'
 import { IUserService } from './IUserService.js'
 import { IUserRepository } from '../../repositories/user/IUserRepository.js'
-import { IPaginationParams, IPaginationResult } from 'helpers/pagination.js'
+import { IPaginationParams, IPaginationResult } from '../../helpers/pagination.js'
 
 export class UserServiceImpl
   extends BaseServiceImpl<IUser, string, Omit<IUser, 'id'>, Partial<Omit<IUser, 'id'>>>


### PR DESCRIPTION
## 📝 Description
- Change 'helpers/' to '../../helpers/'
- Fixes import resolution error in UserRepository, UserServiceImpl, EventRepository

## 🔄 Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor (code improvement without adding new functionality)

## ✅ Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings